### PR TITLE
Potential fix for code scanning alert no. 2: Returning stack-allocated memory

### DIFF
--- a/runtime/vm.c
+++ b/runtime/vm.c
@@ -1190,8 +1190,8 @@ static uint64_t value_hash(Value v) {
         case VAL_BOOL:
             return v.as.boolean ? 1 : 0;
         default:
-            // For other types, use pointer address
-            return (uint64_t)(uintptr_t)&v;
+            // For other types, use pointer address from the value payload
+            return (uint64_t)(uintptr_t)v.as.list;
     }
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Omena0/fr/security/code-scanning/2](https://github.com/Omena0/fr/security/code-scanning/2)

Use a stable, non-stack-derived value in the fallback hash branch.

Best fix (minimal functional change): in `runtime/vm.c`, inside `value_hash` default case (around line 1193–1195), replace `&v` with a stable pointer stored inside the `Value` payload for complex/reference types (matching how equality already compares `a.as.list == b.as.list` in the default branch of `value_equals`).

So change:

- from: `return (uint64_t)(uintptr_t)&v;`
- to: `return (uint64_t)(uintptr_t)v.as.list;`

This keeps existing behavior style (pointer-identity hashing for complex types), removes stack-lifetime misuse, and aligns hashing with equality logic for default/complex types.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Use the pointer stored in the Value payload instead of the address of the stack variable when hashing non-primitive values to prevent invalid memory access and align with equality semantics.